### PR TITLE
Fix issue causing request failure when response_message.content is None.

### DIFF
--- a/search_gpt_core.py
+++ b/search_gpt_core.py
@@ -88,6 +88,8 @@ def main(question):
         return
 
     if response_message.function_call:
+        if not response_message.content:
+            response_message.content = ""
         function_response = process_function_call(response_message)
         if function_response:
             messages.extend([


### PR DESCRIPTION
Fix issue causing request failure when response_message.content is None. 
In  [openai](https://github.com/openai/openai-python) , the function  `client.chat.completions.create()`, content cannot be None.